### PR TITLE
Add position props to SnackBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ SnackBar.show('Making the world happier', {
 })
 ```
 
+A SnackBar at the top.
+```javascript
+SnackBar.show('Making the world happier', {
+  position: 'top' // default to bottom
+})
+```
+
 A SnackBar with nested actions. Always dismiss current SnackBar before showing a new one using the dismiss callback.
 ```javascript
 SnackBar.add('Making the world happier', {

--- a/__tests__/component.js
+++ b/__tests__/component.js
@@ -122,3 +122,41 @@ it('renders SnackBar styles properly', () => {
   expect(buttonWrapper.text()).toBe('<Text />')
   expect([...buttonWrapper.props().style].pop()).toMatchObject({ color: 'blue' })
 })
+
+it('renders SnackBar styles properly on top position', () => {
+  const wrapper = shallow(
+    <SnackBar
+      title='Making the world happier'
+      style={{ marginBottom: 20 }}
+      backgroundColor='white'
+      textColor='yellow'
+      confirmText='Learn more'
+      buttonColor='blue'
+      position='top'
+    />
+  )
+
+  expect(wrapper.text()).toBe('<AnimatedComponent />')
+  // backgroundColor='white'
+  const [originalStyle, ...wrapperStyles] = [...wrapper.props().style]
+  expect(originalStyle.position).toBe('absolute')
+  expect(originalStyle.top).toBe(0)
+  expect(wrapperStyles).toHaveLength(2)
+  expect(wrapperStyles.shift().backgroundColor).toBe('white')
+  expect(wrapperStyles.shift()).toMatchObject({ marginBottom: 20 })
+
+  const inlineWrapper = wrapper.children()
+  expect(inlineWrapper.text()).toBe('<View />')
+  expect(inlineWrapper.children()).toHaveLength(2)
+
+  // textColor='yellow'
+  const titleWrapper = inlineWrapper.children().first()
+  expect(titleWrapper).toHaveLength(1)
+  expect(titleWrapper.text()).toBe('<Text />')
+  expect([...titleWrapper.props().style].pop()).toMatchObject({ color: 'yellow' })
+
+  // buttonColor='blue'
+  const buttonWrapper = inlineWrapper.children().last().children()
+  expect(buttonWrapper.text()).toBe('<Text />')
+  expect([...buttonWrapper.props().style].pop()).toMatchObject({ color: 'blue' })
+})

--- a/src/type.js
+++ b/src/type.js
@@ -1,5 +1,7 @@
 // @flow
 
+type SnackPosition = 'bottom' | 'top';
+
 export type SnackItemType = {
   title: string,
   id?: string, // Once ID is specified, duplicated item won't be added to the queue
@@ -15,6 +17,7 @@ export type SnackItemType = {
   backgroundColor?: string,
   buttonColor?: string,
   textColor?: string,
+  position?: SnackPosition,
 
   // Behaviour
   onAutoDismiss?: Function,


### PR DESCRIPTION
Hi,
First of all, thanks for your component, that is really usefull.

Here is a PR to add position support, to be able to have a snackbar coming from the top.
It add a `position` props to the SnackBar components with `bottom` value by default (for no BC), that support `top` value.

Do not hesitate to ask me if something could be done a better way.

Also, i've got one interrogation with the `isStatic` property : i think it would be more simple to have a third value on position `top|bottom|static` but if i do that, i'll introduce a breaking change :/ WYT ?

Hope you will find that useful. I try to do the best to keep coding style consistent, add a test for the new props, and update flow type to make everything style works the same.

Thanks again.
Kenny
 