### PR TITLE
Fix: add support for react-native 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-react-native": "^1.9.1",
     "prop-types": "^15.6.0",
     "react-mixin": "^3.0.0",
-    "react-native-root-siblings": "^1.1.2",
+    "react-native-root-siblings": "^2.2.0",
     "react-timer-mixin": "^0.13.3",
     "rimraf": "^2.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
   "homepage": "https://github.com/9gag-open-source/react-native-snackbar-dialog#readme",
   "dependencies": {
     "babel-cli": "^6.18.0",
-    "babel-plugin-flow-react-proptypes": "^2.2.0",
+    "babel-plugin-flow-react-proptypes": "^12.1.0",
     "babel-preset-es2016": "^6.16.0",
     "babel-preset-react-native": "^1.9.1",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.6.0",
     "react-mixin": "^3.0.0",
     "react-native-root-siblings": "^1.1.2",
     "react-timer-mixin": "^0.13.3",


### PR DESCRIPTION
Updated dependency to enable react-native 0.50 compatibility.
The older dependency use deprecated react PropType and  EventEmitter.